### PR TITLE
メッセージ中ユーザ一覧画面のエラーを解消

### DIFF
--- a/app/Http/Controllers/MessageController.php
+++ b/app/Http/Controllers/MessageController.php
@@ -62,12 +62,16 @@ class MessageController extends Controller
         // $messages = auth()->user()->messages()->get();
         // // dd($messages);
 
-        $receiver_ids_all   = auth()->user()->all_messages()->groupBy('target_id')->pluck(0)->pluck('target_id');
-        $receiver_ids_order = implode(',', $receiver_ids_all->toArray());
-        $receivers          = $receiver_ids_all->isNotEmpty() ? User::whereIn('id', $receiver_ids_all)->orderByRaw("FIELD(id, $receiver_ids_order)")->get() : [];
+        // $receiver_ids_all   = auth()->user()->all_messages()->groupBy('target_id')->pluck(0)->pluck('target_id');
+        // $receiver_ids_order = implode(',', $receiver_ids_all->toArray());
+        // $receivers          = $receiver_ids_all->isNotEmpty() ? User::whereIn('id', $receiver_ids_all)->orderByRaw("FIELD(id, $receiver_ids_order)")->get() : [];
 
         // dd($receivers);
-        return view('message.index', compact('receivers'));
+
+        // やりとりのあるユーザ毎の最終メッセージを取得
+        $last_messages = $receiver_ids_all   = auth()->user()->all_messages()->groupBy('target_id')->pluck(0);
+
+        return view('message.index', compact('last_messages'));
     }
 
     public function message(User $user)

--- a/resources/views/message/index.blade.php
+++ b/resources/views/message/index.blade.php
@@ -1,4 +1,5 @@
 {{-- <?php dd($receivers->user); ?> --}}
+@inject('User', 'App\Models\User')
 
 <x-app-layout>
     <div class="footer_wrap">
@@ -15,29 +16,26 @@
 
                     <section id="messages">
                         <div>
-                            @foreach ($receivers as $receiver)
+                            @foreach ($last_messages as $message)
                                 @php
-                                    $body = $receiver
-                                        ->messages()
-                                        ->orderBy('created_at', 'desc')
-                                        ->pluck('body');
+                                    $target_user = $User::find($message->target_id);
                                 @endphp
                                 {{-- <?php dd($post->receiver_user_id); ?> --}}
                                 {{-- <?php $titles = \App\Models\Post::where('title', $post->title)->get(); ?> --}}
                                 <div class="user relative">
                                     {{-- @if ($post->receiver_user_id === Auth::user()->id) --}}
-                                    <a href="{{ route('message.message', ['user' => $receiver->id]) }}">
+                                    <a href="{{ route('message.message', ['user' => $target_user->id]) }}">
                                         <div
                                             style="border-bottom: 1px dotted #1A89DA;
                                         padding-bottom: 10px;
                                         padding-top: 5px;">
                                             <div class="mb-2">
                                                 <p class="mr-4 font-bold">
-                                                    {{ $receiver->name }}
+                                                    {{ $target_user->name }}
                                                 </p>
                                                 {{-- <?php dd($body); ?> --}}
                                                 <p class="mt-4 mr-4 font-bold">
-                                                    {{ $body[0] }}
+                                                    {{ $message->body }}
                                                 </p>
                                             </div>
                                             {{-- <p class="text-sm"><span class="mr-2">カテゴリ：<span


### PR DESCRIPTION
## 対応内容
- メッセージ中ユーザ一覧画面のエラーを解消

## エラーが発生する条件
- メッセージ相手がメッセージの受信をしたことがない場合に発生する

## 動作確認方法(テストコマンド、URLなど)
- ユーザ1を新規作成
- ユーザ2を新規作成
- ユーザ1でログインし、ユーザ2へメッセージを送信
- ユーザ2でログインし、メッセージ中ユーザ一覧画面を開くと500エラーが発生していたが、修正後はエラーが発生しない
